### PR TITLE
fix: provide *http.Request to custom error handler

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -94,8 +94,7 @@ func TestWithValidation(t *testing.T) {
 		{
 			name: "POST /users: request error",
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("content-type", "application/json")
-				_ = json.NewEncoder(w).Encode(user{Name: "aereal", Age: 17, ID: "123"})
+				panic("should not reach here")
 			}),
 			request: func(origin string) *http.Request {
 				return mustRequest(newRequest(http.MethodPost, origin+"/users", map[string]string{"content-type": "application/json"}, `{"name":"aereal","age":"abc"}`))

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers/legacy"
 )
 
@@ -37,9 +38,11 @@ func TestWithValidation(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name    string
-		handler http.Handler
-		request func(origin string) *http.Request
+		name           string
+		handler        http.Handler
+		request        func(origin string) *http.Request
+		reqErrReporter func(w http.ResponseWriter, r *http.Request, err error)
+		resErrReporter func(w http.ResponseWriter, r *http.Request, err error)
 	}{
 		{
 			name: "GET /users/{id}: ok",
@@ -62,6 +65,23 @@ func TestWithValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "GET /users/{id}: response error with custom error handler",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("content-type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "aereal", "age": 17})
+			}),
+			request: func(origin string) *http.Request {
+				return mustRequest(newRequest(http.MethodGet, origin+"/users/123", map[string]string{}, ""))
+			},
+			resErrReporter: func(w http.ResponseWriter, r *http.Request, err error) {
+				requestNonNil := r != nil
+				_, errTypeOK := err.(*openapi3filter.ResponseError)
+				w.Header().Set("content-type", "text/plain")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = fmt.Fprintf(w, "the custom response validation error handler is called: errTypeOK=%t, request=%t", errTypeOK, requestNonNil)
+			},
+		},
+		{
 			name: "POST /users: ok",
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("content-type", "application/json")
@@ -81,10 +101,31 @@ func TestWithValidation(t *testing.T) {
 				return mustRequest(newRequest(http.MethodPost, origin+"/users", map[string]string{"content-type": "application/json"}, `{"name":"aereal","age":"abc"}`))
 			},
 		},
+		{
+			name: "POST /users: request error with custom error handler",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				panic("should not reach here")
+			}),
+			request: func(origin string) *http.Request {
+				return mustRequest(newRequest(http.MethodPost, origin+"/users", map[string]string{"content-type": "application/json"}, `{"name":"aereal","age":"abc"}`))
+			},
+			reqErrReporter: func(w http.ResponseWriter, r *http.Request, err error) {
+				requestNonNil := r != nil
+				_, errTypeOK := err.(*openapi3filter.RequestError)
+				w.Header().Set("content-type", "text/plain")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = fmt.Fprintf(w, "the custom response validation error handler is called: errTypeOK=%t, request=%t", errTypeOK, requestNonNil)
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			srv := httptest.NewServer(WithValidation(MiddlewareOptions{Router: router})(testCase.handler))
+			mw := WithValidation(MiddlewareOptions{
+				Router:                        router,
+				ReportRequestValidationError:  testCase.reqErrReporter,
+				ReportResponseValidationError: testCase.resErrReporter,
+			})
+			srv := httptest.NewServer(mw(testCase.handler))
 			defer srv.Close()
 			gotResp, err := srv.Client().Do(testCase.request(srv.URL))
 			if err != nil {

--- a/testdata/TestWithValidation%2FGET_%2Fusers%2F%7Bid%7D%3A_response_error_with_custom_error_handler
+++ b/testdata/TestWithValidation%2FGET_%2Fusers%2F%7Bid%7D%3A_response_error_with_custom_error_handler
@@ -1,0 +1,6 @@
+HTTP/1.1 500 Internal Server Error
+Content-Length: 84
+Content-Type: text/plain
+Date: Fri, 11 Jun 2021 06:57:59 GMT
+
+the custom response validation error handler is called: errTypeOK=true, request=true

--- a/testdata/TestWithValidation%2FPOST_%2Fusers%3A_request_error_with_custom_error_handler
+++ b/testdata/TestWithValidation%2FPOST_%2Fusers%3A_request_error_with_custom_error_handler
@@ -1,0 +1,6 @@
+HTTP/1.1 400 Bad Request
+Content-Length: 84
+Content-Type: text/plain
+Date: Fri, 11 Jun 2021 06:57:59 GMT
+
+the custom response validation error handler is called: errTypeOK=true, request=true


### PR DESCRIPTION
Custom validation error handling may require the HTTP request or `context.Context`. (e.g. for logging)
So this patch proposes to provide `*http.Request`  to the custom validation error handlers of the middleware.