### PR TITLE
feat: add error handler for FindRoute failure

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -14,8 +14,17 @@ type middleware = func(next http.Handler) http.Handler
 
 type MiddlewareOptions struct {
 	Router                        routers.Router
+	ReportFindRouteError          func(w http.ResponseWriter, r *http.Request, err error)
 	ReportRequestValidationError  func(w http.ResponseWriter, r *http.Request, err error)
 	ReportResponseValidationError func(w http.ResponseWriter, r *http.Request, err error)
+}
+
+func (o MiddlewareOptions) reportFindRouteError(w http.ResponseWriter, r *http.Request, err error) {
+	if f := o.ReportFindRouteError; f != nil {
+		f(w, r, err)
+		return
+	}
+	defaultReportFindRouteError(w, err)
 }
 
 func (o MiddlewareOptions) reportReqError(w http.ResponseWriter, r *http.Request, err error) {
@@ -52,7 +61,10 @@ func WithResponseValidation(options MiddlewareOptions) middleware {
 			irw := newBufferingResponseWriter(w)
 			next.ServeHTTP(irw, r)
 			ri, err := buildRequestValidationInputFromRequest(options.Router, r)
-			if err != nil {
+			if frErr, ok := err.(*findRouteErr); ok {
+				options.reportFindRouteError(w, r, frErr.Unwrap())
+				return
+			} else if err != nil {
 				respondErrorJSON(w, http.StatusInternalServerError, err)
 				return
 			}
@@ -81,7 +93,10 @@ func WithRequestValidation(options MiddlewareOptions) middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			input, err := buildRequestValidationInputFromRequest(options.Router, r)
-			if err != nil {
+			if frErr, ok := err.(*findRouteErr); ok {
+				options.reportFindRouteError(w, r, frErr.Unwrap())
+				return
+			} else if err != nil {
 				respondErrorJSON(w, http.StatusInternalServerError, err)
 				return
 			}
@@ -95,10 +110,22 @@ func WithRequestValidation(options MiddlewareOptions) middleware {
 	}
 }
 
+type findRouteErr struct {
+	err error
+}
+
+func (e *findRouteErr) Unwrap() error {
+	return e.err
+}
+
+func (e *findRouteErr) Error() string {
+	return e.err.Error()
+}
+
 func buildRequestValidationInputFromRequest(router routers.Router, r *http.Request) (*openapi3filter.RequestValidationInput, error) {
 	route, pathParams, err := router.FindRoute(r)
 	if err != nil {
-		return nil, err
+		return nil, &findRouteErr{err: err}
 	}
 	input := &openapi3filter.RequestValidationInput{
 		Request:    r,
@@ -114,6 +141,10 @@ type report struct {
 	Value       interface{}      `json:"value"`
 	Schema      *openapi3.Schema `json:"schema"`
 	OriginError string           `json:"origin,omitempty"`
+}
+
+func defaultReportFindRouteError(w http.ResponseWriter, err error) {
+	respondErrorJSON(w, http.StatusInternalServerError, err)
 }
 
 func defaultReportRequestError(w http.ResponseWriter, err error) {

--- a/testdata/TestWithValidation%2FGET_%2Funknown%3A_find_route_error_%28not_found%29
+++ b/testdata/TestWithValidation%2FGET_%2Funknown%3A_find_route_error_%28not_found%29
@@ -1,0 +1,6 @@
+HTTP/1.1 404 Not Found
+Content-Length: 75
+Content-Type: text/plain
+Date: Fri, 27 Aug 2021 07:39:17 GMT
+
+the custom find route error handler is called: errTypeOK=true, request=true

--- a/testdata/TestWithValidation%2FGET_%2Fusers%3A_find_route_error_%28method_not_allowed%29
+++ b/testdata/TestWithValidation%2FGET_%2Fusers%3A_find_route_error_%28method_not_allowed%29
@@ -1,0 +1,6 @@
+HTTP/1.1 405 Method Not Allowed
+Content-Length: 75
+Content-Type: text/plain
+Date: Fri, 27 Aug 2021 07:38:53 GMT
+
+the custom find route error handler is called: errTypeOK=true, request=true


### PR DESCRIPTION
FindRoute fails when method not allowed, or not found endpoints.
However, there are often times when you want to ignore these errors or handle them manually.
So I want to add a new error handler to handle `FindRoute` error manually.